### PR TITLE
Remove reset() method in ObserverWrapper Class

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -1,78 +1,76 @@
 class ObserverWrapper {
-    #observer
-    #selector = 'ytd-app'
-    #isHidden = true
-    #config = { childList: true, subtree: true }
-
     constructor() {
-        this.#observer = undefined
+        this._observer = undefined 
+        this._selector = 'ytd-app'
+        this._isHidden = true
+        this._config = { childList: true, subtree: true } 
     }
 
-    #composeObserver() {
-        const composeBox = document.querySelector(this.#selector)
+    _composeObserver() {
+        const composeBox = document.querySelector(this._selector)
 
-        const mutationObserver = new MutationObserver(this.#handleMutations);
-        mutationObserver.observe(composeBox, this.#config)
+        const mutationObserver = new MutationObserver(this._handleMutations)
+        mutationObserver.observe(composeBox, this._config)
 
-        this.#observer = mutationObserver
+        this._observer = mutationObserver
     }
 
-    #isMenuOption(mutation) {
+    _isMenuOption(mutation) {
         const { localName, innerText } = mutation.target
-        return localName === 'yt-formatted-string' && innerText === 'Add to queue'
+        return localName == 'yt-formatted-string' && innerText === 'Add to queue'
     }
 
-    #isPlaylistIconHover(mutation) {
+    _isPlaylistIconHover(mutation) {
         const { target, addedNodes } = mutation
-        return !!addedNodes?.length && target.id === 'hover-overlays'
+        return !!addedNodes?.length && target.id === 'hover-overlays' 
     }
 
-    #isChildList(mutation) {
+    _isChildList(mutation) {
         return mutation.type === 'childList'
     }
 
-    #filterMutations = (mutation) => {
-        return this.#isChildList(mutation) &&
-            (this.#isPlaylistIconHover(mutation) || this.#isMenuOption(mutation))
+    _filterMutations = (mutation) => {
+        return this._isChildList(mutation) && 
+                (this._isPlaylistIconHover(mutation) || this._isMenuOption(mutation))
     }
 
-    #handleMutations = (mutationsList) => {
-        const filteredList = mutationsList.filter(this.#filterMutations)
+    _handleMutations = (mutationsList) => {
+        const filteredList = mutationsList.filter(this._filterMutations)
 
         if (!filteredList?.length) return
-        this.#toggleQueueUI(filteredList)
+        this._toggleQueueUI(filteredList)
     }
 
-    #toggleQueueUI(mutationsList) {
-        const display = this.#isHidden ? 'none' : 'block'
+    _toggleQueueUI(mutationsList) {
+        const display = this._isHidden ? 'none' : 'block'
 
         for (let mutation of mutationsList) {
             const { target, addedNodes } = mutation
 
-            if (this.#isPlaylistIconHover(mutation)) {
-                const playlistIcon = Array.from(addedNodes).find((a) => a.ariaLabel === 'Add to queue')
+            if (this._isPlaylistIconHover(mutation)) {
+                const playlistIcon = Array.from(addedNodes)
+                  .find(a => a.ariaLabel === 'Add to queue')
                 playlistIcon?.setAttribute('style', `display: ${display}`)
             }
 
-            if (this.#isMenuOption(mutation)) {
-                const element = target.parentElement.parentElement;
+            if (this._isMenuOption(mutation)) {
+                const element = target.parentElement.parentElement
                 element?.setAttribute('style', `display: ${display}`)
             }
         }
     }
 
     hideUI() {
-        this.#isHidden = true
-        if (!this.#observer) {
-            this.#composeObserver()
+        this._isHidden = true
+        if (!this._observer) { 
+            this._composeObserver()
         }
     }
 
     showUI() {
-        this.#isHidden = false
-    }
+        this._isHidden = false 
+    } 
 }
-
 
 function listenForMessage(callback) {
     chrome.runtime.onMessage.addListener(message => {

--- a/content-script.js
+++ b/content-script.js
@@ -70,11 +70,6 @@ class ObserverWrapper {
     showUI() {
         this._isHidden = false 
     } 
-
-    reset() {
-        this._observer?.disconnect()
-        this._observer = undefined
-    }
 }
 
 function listenForMessage(callback) {

--- a/content-script.js
+++ b/content-script.js
@@ -1,76 +1,78 @@
 class ObserverWrapper {
+    #observer
+    #selector = 'ytd-app'
+    #isHidden = true
+    #config = { childList: true, subtree: true }
+
     constructor() {
-        this._observer = undefined 
-        this._selector = 'ytd-app'
-        this._isHidden = true
-        this._config = { childList: true, subtree: true } 
+        this.#observer = undefined
     }
 
-    _composeObserver() {
-        const composeBox = document.querySelector(this._selector)
+    #composeObserver() {
+        const composeBox = document.querySelector(this.#selector)
 
-        const mutationObserver = new MutationObserver(this._handleMutations)
-        mutationObserver.observe(composeBox, this._config)
+        const mutationObserver = new MutationObserver(this.#handleMutations);
+        mutationObserver.observe(composeBox, this.#config)
 
-        this._observer = mutationObserver
+        this.#observer = mutationObserver
     }
 
-    _isMenuOption(mutation) {
+    #isMenuOption(mutation) {
         const { localName, innerText } = mutation.target
-        return localName == 'yt-formatted-string' && innerText === 'Add to queue'
+        return localName === 'yt-formatted-string' && innerText === 'Add to queue'
     }
 
-    _isPlaylistIconHover(mutation) {
+    #isPlaylistIconHover(mutation) {
         const { target, addedNodes } = mutation
-        return !!addedNodes?.length && target.id === 'hover-overlays' 
+        return !!addedNodes?.length && target.id === 'hover-overlays'
     }
 
-    _isChildList(mutation) {
+    #isChildList(mutation) {
         return mutation.type === 'childList'
     }
 
-    _filterMutations = (mutation) => {
-        return this._isChildList(mutation) && 
-                (this._isPlaylistIconHover(mutation) || this._isMenuOption(mutation))
+    #filterMutations = (mutation) => {
+        return this.#isChildList(mutation) &&
+            (this.#isPlaylistIconHover(mutation) || this.#isMenuOption(mutation))
     }
 
-    _handleMutations = (mutationsList) => {
-        const filteredList = mutationsList.filter(this._filterMutations)
+    #handleMutations = (mutationsList) => {
+        const filteredList = mutationsList.filter(this.#filterMutations)
 
         if (!filteredList?.length) return
-        this._toggleQueueUI(filteredList)
+        this.#toggleQueueUI(filteredList)
     }
 
-    _toggleQueueUI(mutationsList) {
-        const display = this._isHidden ? 'none' : 'block'
+    #toggleQueueUI(mutationsList) {
+        const display = this.#isHidden ? 'none' : 'block'
 
         for (let mutation of mutationsList) {
             const { target, addedNodes } = mutation
 
-            if (this._isPlaylistIconHover(mutation)) {
-                const playlistIcon = Array.from(addedNodes)
-                  .find(a => a.ariaLabel === 'Add to queue')
+            if (this.#isPlaylistIconHover(mutation)) {
+                const playlistIcon = Array.from(addedNodes).find((a) => a.ariaLabel === 'Add to queue')
                 playlistIcon?.setAttribute('style', `display: ${display}`)
             }
 
-            if (this._isMenuOption(mutation)) {
-                const element = target.parentElement.parentElement
+            if (this.#isMenuOption(mutation)) {
+                const element = target.parentElement.parentElement;
                 element?.setAttribute('style', `display: ${display}`)
             }
         }
     }
 
     hideUI() {
-        this._isHidden = true
-        if (!this._observer) { 
-            this._composeObserver()
+        this.#isHidden = true
+        if (!this.#observer) {
+            this.#composeObserver()
         }
     }
 
     showUI() {
-        this._isHidden = false 
-    } 
+        this.#isHidden = false
+    }
 }
+
 
 function listenForMessage(callback) {
     chrome.runtime.onMessage.addListener(message => {


### PR DESCRIPTION
Closes #5 

Removed reset() method from `content-script.js` file in `ObserverWrapper Class` as you said it is not used readily.